### PR TITLE
Add Chrome extension to remove Instagram image overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # remove-instagram-image-protection
-Extension to make it easy to save instagram images you find.
+
+This Chrome extension removes the overlay element Instagram places on top of images.
+This allows the browser's context menu (e.g. "Save image as…") to be used.
+
+## Usage
+
+1. Clone or download this repository.
+2. In Chrome, open `chrome://extensions` and enable **Developer mode**.
+3. Choose **Load unpacked** and select this directory.
+4. Browse Instagram and right–click images to save them.

--- a/content.js
+++ b/content.js
@@ -1,0 +1,20 @@
+function removeOverlays() {
+  document.querySelectorAll('div[role="button"]').forEach((container) => {
+    const children = container.children;
+    if (children.length === 2) {
+      const img = children[0].querySelector('img');
+      const overlay = children[1];
+      if (img && overlay.tagName === 'DIV') {
+        overlay.remove();
+      }
+    }
+  });
+}
+
+removeOverlays();
+
+const observer = new MutationObserver(() => {
+  removeOverlays();
+});
+
+observer.observe(document.body, { childList: true, subtree: true });

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 3,
+  "name": "Instagram Image Overlay Remover",
+  "version": "1.0",
+  "description": "Removes overlay divs from Instagram images so they can be saved.",
+  "content_scripts": [
+    {
+      "matches": ["https://www.instagram.com/*", "http://www.instagram.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "permissions": []
+}


### PR DESCRIPTION
## Summary
- Add a content script that removes overlay divs covering Instagram images, enabling the browser's save functionality.
- Provide a manifest for the Chrome extension.
- Update README with usage instructions.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6ee7c45c8321aa56d291fb427fa5